### PR TITLE
Fixed OSX build

### DIFF
--- a/libwasmint/interpreter/SafeAddition.h
+++ b/libwasmint/interpreter/SafeAddition.h
@@ -20,14 +20,8 @@
 
 namespace wasmint {
     inline bool safeSizeTAddition(std::size_t a, std::size_t b, std::size_t* res) {
-        #ifdef __GNUC__
-        #  include <features.h>
-        #  if __GNUC_PREREQ(5,0)
+        #if defined(__GNUC__) && __GNUC__ > 4
             return __builtin_add_overflow(a, b, res);
-        #  else
-            *res = a + b;
-            return *res < a || *res < b;
-        #  endif
         #else
             *res = a + b;
             return *res < a || *res < b;
@@ -36,17 +30,11 @@ namespace wasmint {
 
 
     inline bool safeUInt32Addition(uint32_t a, uint32_t b, uint32_t* res) {
-        #ifdef __GNUC__
-        #  include <features.h>
-        #  if __GNUC_PREREQ(5,0)
-                return __builtin_add_overflow(a, b, res);
-        #  else
-                *res = a + b;
-                return *res < a || *res < b;
-        #  endif
+        #if defined(__GNUC__) && __GNUC__ > 4
+            return __builtin_add_overflow(a, b, res);
         #else
-                *res = a + b;
-                return *res < a || *res < b;
+            *res = a + b;
+            return *res < a || *res < b;
         #endif
     }
 }

--- a/libwasmint/interpreter/at/thread/InterpreterThread.cpp
+++ b/libwasmint/interpreter/at/thread/InterpreterThread.cpp
@@ -38,8 +38,6 @@ namespace wasmint {
         }
     };
 
-    thread_local InterpreterThread * currentThread_ = nullptr;
-
     InterpreterThread::InterpreterThread(MachineState &env) : env_(env) {
     }
 
@@ -111,7 +109,6 @@ namespace wasmint {
     }
 
     void InterpreterThread::stepInternal() {
-        currentThread_ = this;
         getInstructionState().step();
     }
 

--- a/libwasmint/interpreter/at/thread/InterpreterThread.h
+++ b/libwasmint/interpreter/at/thread/InterpreterThread.h
@@ -157,8 +157,6 @@ namespace wasmint {
 
         virtual void serialize(ByteOutputStream& stream) const;
     };
-
-    extern thread_local InterpreterThread * currentThread_;
 }
 
 #endif //WASMINT_INTERPRETER_THREAD_H

--- a/libwasmint/interpreter/heap/Interval.h
+++ b/libwasmint/interpreter/heap/Interval.h
@@ -19,6 +19,7 @@
 #define WASMINT_INTERVAL_H
 
 #include <cstdint>
+#include <cstddef>
 
 namespace wasmint {
     class Interval {


### PR DESCRIPTION
It appears the use of newer GNU features for detecting version do not work in the built-in OSX older version.  Replaced GNU version check with a standard older mechanism.

thread_local is not supported on OSX.  Fortunately, the one variable using thread_local was not effectively in use.

std::size_t required another include on OSX.