### PR TITLE
Mingw fixes

### DIFF
--- a/libwasmint/builtins/RandomModule.h
+++ b/libwasmint/builtins/RandomModule.h
@@ -18,12 +18,8 @@
 #ifndef WASMINT_RANDOMMODULE_H
 #define WASMINT_RANDOMMODULE_H
 
-
-
 #include <Module.h>
 #include <types/Int32.h>
-#include <iostream>
-#include <unistd.h>
 #include <types/Int64.h>
 #include <types/Float32.h>
 #include <types/Float64.h>

--- a/libwasmint/builtins/SpectestModule.h
+++ b/libwasmint/builtins/SpectestModule.h
@@ -18,11 +18,10 @@
 #ifndef WASMINT_SPECTESTMODULE_H
 #define WASMINT_SPECTESTMODULE_H
 
+#include <iostream>
 
 #include <Module.h>
 #include <types/Int32.h>
-#include <iostream>
-#include <unistd.h>
 #include <types/Int64.h>
 #include <types/Float32.h>
 #include <types/Float64.h>
@@ -87,6 +86,7 @@ namespace wasmint {
             return module;
         }
 
+#undef stdout
         static std::stringstream& stdout() {
             return stdout_;
         }

--- a/libwasmint/builtins/StdioModule.cpp
+++ b/libwasmint/builtins/StdioModule.cpp
@@ -14,4 +14,62 @@
  * limitations under the License.
  */
 
+#include <iostream>
+
+#include <types/Int32.h>
+#include <types/Int64.h>
+#include <types/Float32.h>
+#include <types/Float64.h>
+
 #include "StdioModule.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace wasmint {
+
+wasm_module::Module* StdioModule::create() {
+    using namespace wasm_module;
+    Module* module = new Module();
+    module->context().name("stdio");
+
+    module->addVariadicFunction("print", Void::instance(),
+                                [](std::vector<Variable> parameters) {
+
+                                        for (const Variable& parameter : parameters) {
+                                            std::cout << "print ";
+
+                                            if (&parameter.type() == Int32::instance()) {
+                                                std::cout << parameter.int32();
+                                            } else if (&parameter.type() == Int64::instance()) {
+                                                std::cout << parameter.int64();
+                                            } else if (&parameter.type() == Float32::instance()) {
+                                                std::cout << parameter.float32();
+                                            } else if (&parameter.type() == Float64::instance()) {
+                                                std::cout << parameter.float64();
+                                            } else {
+                                                std::cout << "Unknown type to print" << parameter.type().name();
+                                            }
+                                            std::cout << std::endl;
+
+                                        }
+
+                                        return Void::instance();
+                                    });
+
+        module->addFunction("sleep", Void::instance(), {Int32::instance()},
+                                    [](std::vector<Variable> parameters) {
+#ifdef _WIN32
+                                        Sleep(Int32::getValue(parameters.at(0)));
+#else
+                                        usleep(Int32::getValue(parameters.at(0)));
+#endif
+                                        return Void::instance();
+                                    });
+        return module;
+}
+
+}

--- a/libwasmint/builtins/StdioModule.h
+++ b/libwasmint/builtins/StdioModule.h
@@ -17,55 +17,13 @@
 #ifndef WASMINT_STDIOMODULE_H
 #define WASMINT_STDIOMODULE_H
 
-
 #include <Module.h>
-#include <types/Int32.h>
-#include <iostream>
-#include <unistd.h>
-#include <types/Int64.h>
-#include <types/Float32.h>
-#include <types/Float64.h>
 
 namespace wasmint {
     class StdioModule {
 
     public:
-        static wasm_module::Module* create() {
-            using namespace wasm_module;
-            Module* module = new Module();
-            module->context().name("stdio");
-
-            module->addVariadicFunction("print", Void::instance(),
-                                        [](std::vector<Variable> parameters) {
-
-                                            for (const Variable& parameter : parameters) {
-                                                std::cout << "print ";
-
-                                                if (&parameter.type() == Int32::instance()) {
-                                                    std::cout << parameter.int32();
-                                                } else if (&parameter.type() == Int64::instance()) {
-                                                    std::cout << parameter.int64();
-                                                } else if (&parameter.type() == Float32::instance()) {
-                                                    std::cout << parameter.float32();
-                                                } else if (&parameter.type() == Float64::instance()) {
-                                                    std::cout << parameter.float64();
-                                                } else {
-                                                    std::cout << "Unknown type to print" << parameter.type().name();
-                                                }
-                                                std::cout << std::endl;
-
-                                            }
-
-                                            return Void::instance();
-                                        });
-
-            module->addFunction("sleep", Void::instance(), {Int32::instance()},
-                                        [](std::vector<Variable> parameters) {
-                                            usleep(Int32::getValue(parameters.at(0)));
-                                            return Void::instance();
-                                        });
-            return module;
-        }
+        static wasm_module::Module* create();
     };
 }
 


### PR DESCRIPTION
Some changes to make it compile with Mingw on Windows.

- Remove `unistd.h` when it is not used at all.
- Use `Sleep` from `windows.h` (included in source file instead of header file because `windows.h` defines too much macro and types that will cause name clashing) for Windows.
- Un-define `stdout` in `libwasmint/builtins/SpectestModule.h` because for some reason `stdout` from `stdio.h` found its way into the code.

MSVC still doesn't work due to [`Fatal error C1061: compiler limit: blocks nested too deeply`](https://msdn.microsoft.com/en-us/library/dcda4f64.aspx) in [`wasm-module/src/instructions/InstructionSet.cpp`](https://github.com/WebAssembly/wasmint/blob/master/wasm-module/src/instructions/InstructionSet.cpp#L128)