### PR TITLE
MSVC fix

### DIFF
--- a/libwasmint/tests/fuzzing/DataRescuer.h
+++ b/libwasmint/tests/fuzzing/DataRescuer.h
@@ -1,9 +1,8 @@
 #ifndef WASMINT_DATARESCUER_H
 #define WASMINT_DATARESCUER_H
 
-#include<stdio.h>
-#include<signal.h>
-#include<unistd.h>
+#include <stdio.h>
+#include <signal.h>
 #include <iostream>
 
 namespace wasmint {

--- a/libwasmint/tests/performance/QuickSortSource.h
+++ b/libwasmint/tests/performance/QuickSortSource.h
@@ -18,6 +18,8 @@
 #ifndef WASMINT_QUICKSORTSOURCE_H
 #define WASMINT_QUICKSORTSOURCE_H
 
+#include <string>
+
 #include "PiDigits.h"
 
 const std::string quickSortSource =

--- a/wasm-to-c/ModuleConverter.cpp
+++ b/wasm-to-c/ModuleConverter.cpp
@@ -23,6 +23,7 @@
 #include "FunctionConverter.h"
 #include <algorithm>
 #include <iostream>
+#include <cctype>
 #include <instructions/Instructions.h>
 #include <assert.h>
 


### PR DESCRIPTION
With [`8823b44`](https://github.com/WebAssembly/wasmint/commit/8823b4404447379aa0c9b548e4edcad45e31006b) and this PR, MSVC can at least build the two libraries, `wasmint.exe` and `wasm2c.exe`.